### PR TITLE
Fix render's binding to document.body instead of the container.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ function render(ui: Ui, options: Options = {}): Result {
         ? el.forEach(e => console.log(prettyDOM(e, maxLength, options)))
         : console.log(prettyDOM(el, maxLength, options)),
     unmount: dispose,
-    ...getQueriesForElement(baseElement, queries)
+    ...getQueriesForElement(container, queries)
   } as Result;
 }
 


### PR DESCRIPTION
Tested with,
```javascript
test("the query container should not be document.body", () => {
  const { container, getAllByText } = render(() => <div>Some text...</div>);
  const falseContainer = document.createElement("p");
  falseContainer.textContent = "Some text...";
  container.parentNode.insertBefore(falseContainer, getAllByText("Some text...")[0].parentNode);
  expect(getAllByText("Some text...")[0] === container.childNodes[0]).toBe(true);
});
```

The test appends a false container with the same text as the rendered container. It is on the same level with the rendered container, but before the rendered container.

Then it checks if the queried element is the same with the child of `container`, which should be the original element. But before the fix it wouldn't be, as the query is bound to the document.body instead of the container. After the fix, it would be, as now the query is bound to the container instead of the document.body.

Before fix,
![before-change](https://user-images.githubusercontent.com/78088355/180436177-e072366e-a54d-4485-8845-9a0333b42422.PNG)

After fix,
![after-change](https://user-images.githubusercontent.com/78088355/180436253-ba97eb9b-d672-4219-9978-33689c7bf355.PNG)
