### PR TITLE
Specify queries to make TypeScript aware of `render` methods

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
+import type { BoundFunction, prettyFormat, Queries, queries } from "@testing-library/dom";
 import type { JSX } from "solid-js";
-import type { Queries, BoundFunction, prettyFormat } from "@testing-library/dom";
 
 export interface Ref {
   container: HTMLElement;
@@ -15,7 +15,7 @@ export interface Options {
   hydrate?: boolean;
 }
 
-export type Extra = { [P in keyof Queries]: BoundFunction<Queries[P]> };
+export type Extra<Q extends Queries = typeof queries> = { [P in keyof Q]: BoundFunction<Q[P]> };
 
 export type DebugFn = (
   baseElement?: HTMLElement | HTMLElement[],


### PR DESCRIPTION
This fixes autocompete in VS Code.
Inspired by https://github.com/testing-library/react-testing-library/blob/c80809a956b0b9f3289c4a6fa8b5e8cc72d6ef6d/types/index.d.ts#L14

Before:
<img width="917" alt="Screenshot 2022-07-24 at 13 44 36" src="https://user-images.githubusercontent.com/75225148/180643584-31bb4036-9a37-4ec7-92aa-63880d838338.png">

After:

https://user-images.githubusercontent.com/75225148/180643594-09bd5eb4-5884-4931-9956-265da6a15319.mov


