### PR TITLE
Fix For Test Calling `fireEvent` Directly

### DIFF
--- a/src/__tests__/events.tsx
+++ b/src/__tests__/events.tsx
@@ -175,10 +175,11 @@ test("calling `fireEvent` directly works too", () => {
 
   fireEvent(
     button!,
-    new Event("MouseEvent", {
+    new MouseEvent("click", {
       bubbles: true,
-      cancelable: true,
-      button: 0
-    } as any)
+      cancelable: true
+    })
   );
+
+  expect(handleEvent).toHaveBeenCalledTimes(1);
 });


### PR DESCRIPTION
This PR fixes the test for calling `fireEvent` directly in [*src/\_\_tests__/events.tsx*](https://github.com/solidjs/solid-testing-library/blob/37b3fd79224d2040fb997309be9933514c5f1c1e/src/__tests__/events.tsx#L169).

The current test doesn't contain an `expect` statement and doesn't raise the click event. Using `MouseEvent` instead of just `Event("click")` removes the need to type convert and initialise `button: 0`.
