### PR TITLE
docs: added link to the solidjs template ts-vitest

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ practices.</p>
 
 > Inspired completely by [preact-testing-library](https://github.com/testing-library/preact-testing-library)
 
-[![Coverage Status](https://img.shields.io/coveralls/github/ryansolid/solid-testing-library.svg?style=flat)](https://coveralls.io/github/ryansolid/solid-testing-library?branch=main)
+[![Coverage Status](https://coveralls.io/repos/github/ryansolid/solid-testing-library/badge.svg?branch=main)](https://coveralls.io/github/ryansolid/solid-testing-library?branch=main)
 [![NPM Version](https://img.shields.io/npm/v/solid-testing-library.svg?style=flat)](https://www.npmjs.com/package/solid-testing-library)
 [![](https://img.shields.io/npm/dm/solid-testing-library.svg?style=flat)](https://www.npmjs.com/package/solid-testing-library)
 [![Discord](https://img.shields.io/discord/722131463138705510)](https://discord.com/invite/solidjs)

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ If you using Jest we recommend using [solid-jest](https://github.com/solidjs/sol
 💡 If you are using Jest or vitest, you may also be interested in installing `@testing-library/jest-dom` so you can use
 [the custom jest matchers](https://github.com/testing-library/jest-dom).
 
+## Integration with Vite
+
+A working Vite template setup with `solid-testing-library` and TypeScript support can be found [here](https://github.com/solidjs/templates/tree/master/ts-vitest).
+
 ## Docs
 
 See the [docs](https://testing-library.com/docs/preact-testing-library/intro) over at the Testing Library website.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you using Jest we recommend using [solid-jest](https://github.com/solidjs/sol
 
 ## Integration with Vite
 
-A working Vite template setup with `solid-testing-library` and TypeScript support can be found [here](https://github.com/solidjs/templates/tree/master/ts-vitest).
+A working Vite template setup with `solid-testing-library` and TypeScript support can be found [here](https://github.com/solidjs/solid-start/tree/main/examples/with-vitest).
 
 ## Docs
 


### PR DESCRIPTION
I was looking here and there for a good template / setup on how to use `solid-testing-library` because the docs link refers to the preact testing library implementation and of course, config differs for the Vite setup etc.pp. 

However, we have a working template in the repo over here: https://github.com/solidjs/templates/tree/master/ts-vitest

Let's add this section in the readme to make it easier for people to find out how to use this great testing library and to have less frequency of questions on Discord :)

edit: also fixed the broken badge :)