### PR TITLE
Add `.d.cts` file to fix compatibility with `moduleResolution: node16`

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   ],
   "scripts": {
     "prepublishOnly": "npm run build",
-    "build": "tsup src/index.ts --format esm,cjs --dts --clean",
+    "build": "tsup src/index.ts --format esm,cjs --dts --clean && cp dist/index.d.ts dist/index.d.cts",
     "typecheck": "tsc --noEmit; tsc --noEmit --project src/__tests__/tsconfig.json",
     "test": "vitest",
     "test:watch": "npm test --watch",


### PR DESCRIPTION
Currently TypeScript is not able to pick up any types from CJS modules, see the confirmation of that problem [here](https://arethetypeswrong.github.io/?p=%40solidjs%2Ftesting-library%400.7.1) and [here](https://www.typescriptlang.org/play?moduleResolution=3&target=99&module=1&ts=5.1.3&Module=true#code/PTAEAEFsHsBMFcA2BTASsgztR8AuBLaAOwC5Qi5kBGANgFgAoECGBFMgY2khiICsMjRvkgAHaACdcoAN6gJyIrGQTQAX1AAzCd1ABycFkT5YA4LkwEiAcwC0xgEYSAhhICee0M1xvRmMgAMAHQA7EFUjEA).

