### PR TITLE
refactor: remove Routes from uses params example

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ Solid.js reactive changes are pretty instantaneous, so there is rarely need to u
 ```tsx
 it('uses params', async () => {
   const App = () => (
-    <Routes>
+    <>
       <Route path="/ids/:id" component={() => <p>Id: {useParams()?.id}</p>} />
       <Route path="/" component={() => <p>Start</p>} />
-    </Routes>
+    </>
   ); 
   const { findByText } = render(() => <App />, { location: "ids/1234" });
   expect(await findByText("Id: 1234")).not.toBeFalsy();


### PR DESCRIPTION
Due to the fact that Routes were removed from Solid Router the `use-params` test needs to be updated.
In this PR, I removed Routes and replaced with it with a Fragment. Given that render wraps the component with Router, this should work. Please let me know if I missed something or if I am unaware of an issue with this approach!