### PR TITLE
fix: check for process

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ import type {
 } from "./types";
 
 /* istanbul ignore next */
-if (!process.env.STL_SKIP_AUTO_CLEANUP) {
+if (typeof process === 'undefined' || !process.env.STL_SKIP_AUTO_CLEANUP) {
   //@ts-ignore
   if (typeof afterEach === "function") { afterEach(cleanup); }
 }


### PR DESCRIPTION
Trying `solid-testing-library` in the Vitest Browser Mode shows an error that `process` is not defined. testing-library has guards in other places for `process`, so I would expect it to also be defined here.