### PR TITLE
ci(test): scope `GITHUB_TOKEN` to `contents: read`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Tests workflow only does checkout + setup-node + `pnpm i` + `pnpm test`. No API writes, so `contents: read` is the right cap for the default token.

CVE-2025-30066 (`tj-actions/changed-files`) is the recent reminder that any unspoken scope can be exfiltrated from caller workflow logs. YAML validated locally.